### PR TITLE
Update README: Add command for Ubuntu 24.04

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,8 +71,10 @@ Install the dependency libs.
 cd ~/apps-md-robots/ai-app/
 sudo apt-get install -y python3-pyaudio
 sudo apt-get install -y libgl1
-sudo pip install -r requirements.txt 
-
+sudo apt-get install -y portaudio19-dev
+sudo pip install msgpack --break-system-packages
+sudo pip install pillow --break-system-packages
+sudo pip install -r requirements.txt --break-system-packages 
 sudo cp ai.service /etc/systemd/system/ai.service
 ```
 


### PR DESCRIPTION
## Summary
Add missing dependencies and pip flags to README installation instructions for ai-app (ubuntu 24).

## Changes Made
- **Added portaudio19-dev**: Required development headers for audio processing
- **Added msgpack installation**: Fast serialization library dependency  
- **Added pillow installation**: Python imaging library for image processing
- **Added --break-system-packages flag**: Required for pip installations on newer Python/Ubuntu versions

## Problem Solved
The current installation instructions were incomplete and would fail on:
- Systems missing audio development headers
- Missing required Python packages (msgpack, pillow)
- Ubuntu 24.04+ systems where pip requires --break-system-packages flag

